### PR TITLE
Prevent Downshift's default Home and End event handlers

### DIFF
--- a/src/members/TDSelector.jsx
+++ b/src/members/TDSelector.jsx
@@ -178,7 +178,13 @@ export const TDSelector = ({
                 })}
               >
                 <input
-                  {...getInputProps()}
+                  {...getInputProps({
+                    onKeyDown: event => {
+                      if (event.key === "Home" || event.key === "End") {
+                        event.nativeEvent.preventDownshiftDefault = true;
+                      }
+                    }
+                  })}
                   disabled={optionsLoading}
                   className="input"
                   type="text"


### PR DESCRIPTION
because they're not WAI-ARIA compliant (see https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html)